### PR TITLE
Reject requests with body when non expected

### DIFF
--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -97,6 +97,11 @@ func ValidateRequest(ctx context.Context, input *RequestValidationInput) error {
 			}
 			me = append(me, err)
 		}
+	} else if requestBody == nil && !options.ExcludeRequestBody && input.Request.ContentLength > 0 {
+		return &RequestError{
+				Input: input,
+				Err:   fmt.Errorf("request body not allowed for this request"),
+			}
 	}
 
 	if len(me) > 0 {


### PR DESCRIPTION
When a the specification does not specify a request body but one is included the validation currently passes.

This change will reject the request.

An example use case is when validation a DELETE request where you do not expect a body.